### PR TITLE
Does not work with generated folder and compass 0.12.2

### DIFF
--- a/stylesheets/_compass-hdpi.scss
+++ b/stylesheets/_compass-hdpi.scss
@@ -7,9 +7,11 @@ $disable-hdpi: false !default;
 // Force HDPI
 $force-hdpi: false !default;
 
-// This must be set if using a generated images folder. This is a workaround for
-// a compass 0.12.2 bug. https://github.com/chriseppstein/compass/issues/1077
-//$generated-image-folder: "generated";
+// This must be set to generated images folder relative to images set in
+// config.rb if using a generated images folder. E.g 'generated'.
+// This is a workaround for a compass 0.12.2 bug.
+// @see https://github.com/chriseppstein/compass/issues/1077
+$generated-image-folder: false !default;
 
 // Set background-size property based on an image size
 @mixin image-background-size($image) {


### PR DESCRIPTION
 If using a generated images folder defined in config rb. Example:

```
generated_images_dir = "images/generated"
```

You get an error such as this:

```
 No such file or directory - {path to site}/images/icons-s66517bab07.png
```

Where it should be looking in:

```
{path to site}/images/generated/icons-s66517bab07.png
```

In this workaround the user would have to set a variable for the generated image path. There is probably a more elegant way of doing this.
