### PR TITLE
Additional/altered functionality 

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,15 +114,15 @@ If `$dimensions` is `true`, the sprite dimensions will specified.
 
 ## Images
 
-### @mixin background-hdpi($image, $image-hdpi, $dimensions)
+### @mixin background-hdpi($image, $image-hdpi, $attributes, $dimensions)
 
 Set a normal and HDPI background and optionally, attributes and dimensions.
 
 #### Arguments
 
- - `$image`: normal image path.
- - `$image`: HDPI image path.
- - `$attr`: Additional background property values (default to '')
+ - `$image`: normal image path
+ - `$image-hdpi`: HDPI image path
+ - `$attributes`: Additional background property values (default to '')
  - `$dimensions`: set element dimensions based on image size (boolean, default to `false`)
 
 
@@ -131,20 +131,20 @@ Set a normal and HDPI background and optionally, attributes and dimensions.
     @import "compass-hdpi";
 
     .logo {
-      @include background-image-hdpi(icons/logo.png, icons/logo@2x.png, no-repeat top left);
+      @include background-hdpi(icons/logo.png, icons/logo@2x.png, no-repeat top left);
     }
 
 
-### @mixin inline-background-hdpi($image, $image-hdpi, $dimensions)
+### @mixin inline-background-hdpi($image, $image-hdpi, $attributes, $dimensions)
 
 Set a normal and HDPI inline background and optionally, attributes and dimensions.
 
 
 #### Arguments
 
- - `$image`: normal image path.
- - `$image`: HDPI image path.
- - `$attr`: Additional background property values (default to '')
+ - `$image`: normal image path
+ - `$image-hdpi`: HDPI image path
+ - `$attributes`: Additional background property values (default to '')
  - `$dimensions`: set element dimensions based on image size (boolean, default to `false`)
 
 
@@ -153,7 +153,7 @@ Set a normal and HDPI inline background and optionally, attributes and dimension
     @import "compass-hdpi";
 
     .logo {
-      @include inline-background-image-hdpi(icons/logo.png, icons/logo@2x.png, no-repeat top left, true);
+      @include inline-background-hdpi(icons/logo.png, icons/logo@2x.png, no-repeat top left, true);
       @include hide-text;
     }
 

--- a/README.md
+++ b/README.md
@@ -114,13 +114,14 @@ If `$dimensions` is `true`, the sprite dimensions will specified.
 
 ## Images
 
-### @mixin background-image-hdpi($image, $image-hdpi, $dimensions)
+### @mixin background-hdpi($image, $image-hdpi, $dimensions)
 
-Set a normal and HDPI background and optionally, attributes and dimensions. You must have a {filename}-x2.png file in the same directory and twice the size as your {filename}.png file.
+Set a normal and HDPI background and optionally, attributes and dimensions.
 
 #### Arguments
 
- - `$image`: normal image path without file extension.
+ - `$image`: normal image path.
+ - `$image`: HDPI image path.
  - `$attr`: Additional background property values (default to '')
  - `$dimensions`: set element dimensions based on image size (boolean, default to `false`)
 
@@ -130,18 +131,19 @@ Set a normal and HDPI background and optionally, attributes and dimensions. You 
     @import "compass-hdpi";
 
     .logo {
-      @include background-image-hdpi(icons/logo, no-repeat top left);
+      @include background-image-hdpi(icons/logo.png, icons/logo@2x.png, no-repeat top left);
     }
 
 
-### @mixin inline-background-image-hdpi($image, $image-hdpi, $dimensions)
+### @mixin inline-background-hdpi($image, $image-hdpi, $dimensions)
 
-Set a normal and HDPI inline background and optionally, attributes and dimensions. You must have a {filename}-x2.png file in the same directory and twice the size as your {filename}.png file.
+Set a normal and HDPI inline background and optionally, attributes and dimensions.
 
 
 #### Arguments
 
- - `$image`: normal image path without file extension.
+ - `$image`: normal image path.
+ - `$image`: HDPI image path.
  - `$attr`: Additional background property values (default to '')
  - `$dimensions`: set element dimensions based on image size (boolean, default to `false`)
 
@@ -151,7 +153,7 @@ Set a normal and HDPI inline background and optionally, attributes and dimension
     @import "compass-hdpi";
 
     .logo {
-      @include inline-background-image-hdpi(icons/logo, no-repeat top left, true);
+      @include inline-background-image-hdpi(icons/logo.png, icons/logo@2x.png, no-repeat top left, true);
       @include hide-text;
     }
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Compass HDPI
 
-Compass mixins for dealing with HDPI (a.k.a. Retina) sprites and images in your CSS.  
+Compass mixins for dealing with HDPI (a.k.a. Retina) sprites and images in your CSS.
 Based on [Compass Sprite Base](https://github.com/chriseppstein/compass/blob/stable/frameworks/compass/stylesheets/compass/utilities/sprites/_base.scss) ([doc](http://compass-style.org/reference/compass/utilities/sprites/base/)).
 
 
@@ -14,7 +14,7 @@ Add the following lines in your Gemfile :
     gem "compass", ">= 0.12.2"
     gem "sass", ">= 3.2.0"
 
-And run 
+And run
 
     bundle install
 
@@ -39,7 +39,7 @@ Include the position and (optionally) dimensions of this `$sprite` in the given 
 
 #### Arguments
 
- - `$map`: normal `sprite-map` 
+ - `$map`: normal `sprite-map`
  - `$map-hdpi`: HDPI `sprite-map`
  - `$sprite`: sprite name
  - `$dimensions`: set element dimensions based on sprite size (boolean, default to `false`)
@@ -71,7 +71,7 @@ If `$dimensions` is `true`, the sprite dimensions will specified.
 
 #### Arguments
 
- - `$map`: normal `sprite-map` 
+ - `$map`: normal `sprite-map`
  - `$map-hdpi`: HDPI `sprite-map`
  - `$sprites`: sprites names (default to all sprites)
  - `$base-class`: class to extend (default to false)
@@ -98,7 +98,7 @@ If `$dimensions` is `true`, the sprite dimensions will specified.
 
 
 #### Example #2
-    
+
     @import "compass-hdpi";
 
     $sprites: sprite-map("sprites/*.png");
@@ -116,13 +116,12 @@ If `$dimensions` is `true`, the sprite dimensions will specified.
 
 ### @mixin background-image-hdpi($image, $image-hdpi, $dimensions)
 
-Set a normal and HDPI background-image and (optionally) its dimensions
-
+Set a normal and HDPI background and optionally, attributes and dimensions. You must have a {filename}-x2.png file in the same directory and twice the size as your {filename}.png file.
 
 #### Arguments
 
- - `$image`: normal image path
- - `$image-hdpi`: HDPI image path
+ - `$image`: normal image path without file extension.
+ - `$attr`: Additional background property values (default to '')
  - `$dimensions`: set element dimensions based on image size (boolean, default to `false`)
 
 
@@ -131,20 +130,19 @@ Set a normal and HDPI background-image and (optionally) its dimensions
     @import "compass-hdpi";
 
     .logo {
-      @include background-image-hdpi("logo.png", "logo@2x.png", true);
-      @include hide-text;
+      @include background-image-hdpi(icons/logo, no-repeat top left);
     }
 
 
 ### @mixin inline-background-image-hdpi($image, $image-hdpi, $dimensions)
 
-Set a normal and HDPI inline background-image and (optionally) its dimensions
+Set a normal and HDPI inline background and optionally, attributes and dimensions. You must have a {filename}-x2.png file in the same directory and twice the size as your {filename}.png file.
 
 
 #### Arguments
 
- - `$image`: normal image path
- - `$image-hdpi`: HDPI image path
+ - `$image`: normal image path without file extension.
+ - `$attr`: Additional background property values (default to '')
  - `$dimensions`: set element dimensions based on image size (boolean, default to `false`)
 
 
@@ -153,10 +151,8 @@ Set a normal and HDPI inline background-image and (optionally) its dimensions
     @import "compass-hdpi";
 
     .logo {
-      height: 50px;
-      width: 100px;
+      @include inline-background-image-hdpi(icons/logo, no-repeat top left, true);
       @include hide-text;
-      @include inline-background-image-hdpi("logo.png", "hdpi/logo.png");
     }
 
 ---
@@ -191,8 +187,8 @@ You can also override the whole media query with the `$media-hdpi` variable whic
 
     $media-hdpi: "(-webkit-min-device-pixel-ratio: 1.5), (min-resolution: 144dpi)" !default;
 
-For exemple, you can use [Thomas Fuchs](http://retinafy.me/) media query : 
-    
+For exemple, you can use [Thomas Fuchs](http://retinafy.me/) media query :
+
     $media-hdpi: "(min--moz-device-pixel-ratio: 1.5),
       (-o-min-device-pixel-ratio: 150/100),
       (-webkit-min-device-pixel-ratio: 1.5),
@@ -208,3 +204,11 @@ You can force HDPI assets on normal screens by setting the `$force-hdpi` variabl
 You can also totally disable HDPI assets by setting the `$disable-hdpi` variable to `true` (default to `false`)
 
     $disable-hdpi: false !default;
+
+You can set the dimension styles by default when using background-hdpi() by setting the `$background-hdpi-dimensions` variable to `true` (default to `false`)
+
+    $background-hdpi-dimensions: false !default;
+
+If using a generated images folder and compass 0.12.2, the `$generated-image-folder` variable must be set to the generated images folder relative to images folder set in config.rb, for example 'generated' (default to `false`)
+
+    $generated-image-folder: false !default;

--- a/README.md
+++ b/README.md
@@ -205,10 +205,18 @@ You can also totally disable HDPI assets by setting the `$disable-hdpi` variable
 
     $disable-hdpi: false !default;
 
-You can set the dimension styles by default when using background-hdpi() by setting the `$background-hdpi-dimensions` variable to `true` (default to `false`)
+You can disable the dimension styles by default when using `sprite-hdpi()` by setting the `$background-hdpi-dimensions` variable to `false` (default to `true`)
+
+    $sprite-hdpi-dimensions: true !default;
+
+You can set the background image by default when using `sprite-hdpi()` by setting the `$sprite-hdpi-set-background` variable to `true` (default to `false`)
+
+    $sprite-hdpi-set-background: false !default;
+
+You can set the dimension styles by default when using `background-hdpi()` and `inline-background-hdpi()` by setting the `$background-hdpi-dimensions` variable to `true` (default to `false`)
 
     $background-hdpi-dimensions: false !default;
 
-If using a generated images folder and compass 0.12.2, the `$generated-image-folder` variable must be set to the generated images folder relative to images folder set in config.rb, for example 'generated' (default to `false`)
+If using a generated images folder and compass 0.12.2, the `$generated-image-folder` variable must be set to the generated images folder relative to images folder set in config.rb, for example `'generated'` (default to `false`)
 
     $generated-image-folder: false !default;

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Simply download and copy `stylesheets/_compass-hdpi.scss` in your `sass` directo
 
 ## Sprites
 
-### @mixin sprite-hdpi($map, $map-hdpi, $sprite, $dimensions, $offset-x, $offset-y, $set-background-image)
+### @mixin sprite-hdpi($sprite, $map, $map-hdpi, $dimensions, $offset-x, $offset-y, $set-background-image)
 
 Include the position and (optionally) dimensions of this `$sprite` in the given sprite `$map` and `$map-hdpi`. The sprite url should come from either a base class or you can specify the `sprite-url` explicitly like this, except if `$set-background-image` is set to true:
 
@@ -39,9 +39,9 @@ Include the position and (optionally) dimensions of this `$sprite` in the given 
 
 #### Arguments
 
+ - `$sprite`: sprite name
  - `$map`: normal `sprite-map`
  - `$map-hdpi`: HDPI `sprite-map`
- - `$sprite`: sprite name
  - `$dimensions`: set element dimensions based on sprite size (boolean, default to `false`)
  - `$set-background`: set `.prefix` element default `background-image` and `background-repeat` (boolean, default to `false`)
 
@@ -55,7 +55,25 @@ Include the position and (optionally) dimensions of this `$sprite` in the given 
 
     .icon-facebook {
       background: $icons no-repeat;
-      @include sprite($icons, $icons-hdpi, facebook, true);
+      @include sprite-hdpi(facebook, $icons, $icons-hdpi);
+    }
+
+You can also set the default maps using `$sprite-hdpi-default-map` and `$prite-hdpi-defailt-map-hdpi`
+
+
+#### Example
+
+    @import "compass-hdpi";
+
+    $icons: sprite-map("icons/*.png");
+    $icons-hdpi: sprite-map("icons@2x/*.png");
+
+    $sprite-hdpi-default-map: $icons;
+    $sprite-hdpi-default-map-hdpi: $icons-hdpi;
+
+    .icon-facebook {
+      background: $icons no-repeat;
+      @include sprite-hdpi(facebook);
     }
 
 
@@ -206,6 +224,11 @@ You can force HDPI assets on normal screens by setting the `$force-hdpi` variabl
 You can also totally disable HDPI assets by setting the `$disable-hdpi` variable to `true` (default to `false`)
 
     $disable-hdpi: false !default;
+
+You can dset the default maps when using `sprite-hdpi()` by setting the `$background-hdpi-default-map` and `$background-hdpi-default-map-hdpi` variables to your desired default maps. (default to `false`)
+
+    $sprite-hdpi-default-map: false !default;
+    $sprite-hdpi-default-map-hdpi: false !default;
 
 You can disable the dimension styles by default when using `sprite-hdpi()` by setting the `$background-hdpi-dimensions` variable to `false` (default to `true`)
 

--- a/stylesheets/_compass-hdpi.scss
+++ b/stylesheets/_compass-hdpi.scss
@@ -7,6 +7,9 @@ $disable-hdpi: false !default;
 // Force HDPI
 $force-hdpi: false !default;
 
+// Generate dimension styles when using background-hdpi().
+$background-hdpi-dimensions: false !default;
+
 // This must be set to generated images folder relative to images set in
 // config.rb if using a generated images folder. E.g 'generated'.
 // This is a workaround for a compass 0.12.2 bug.
@@ -148,26 +151,51 @@ $generated-image-folder: false !default;
   }
 }
 
-// Set a normal and HDPI background-image and (optionally) its dimensions
-@mixin background-image-hdpi($image, $image-hdpi, $dimensions: false) {
+// Set a normal and HDPI background and optionally, attributes and dimensions.
+//
+// You must have a {filename}-x2 file in the same directory and twice the size
+// as your {filename} file.
+//
+// Example:
+//   li {
+//     @include background-hdpi(logo);
+//   }
+//   .facebook-icon {
+//     @include background-hdpi(social/facebook, #fff no-repeat right);
+//   }
+//
+// @param {String} $image normal image path without file extension.
+// @param {Object} $attr additional background property values.
+// @param {Boolean} $dimensions specify image dimensions.
+@mixin background-hdpi($image, $attr: '', $dimensions: $background-hdpi-dimensions) {
+  $image-hdpi: $image + "-x2.png";
+  $image: $image + ".png";
   background-image: image-url($image);
+  @if $attr != '' {
+    background: $attr;
+  }
   @if $dimensions {
     @include image-dimensions($image);
   }
   @include media-hdpi {
     background-image: image-url($image-hdpi);
-    @include image-background-size($image);
+    @include background-size(image-width($image) image-height($image));
   }
 }
 
-// Same as `background-image-hdpi` but inline
-@mixin inline-background-image-hdpi($image, $image-hdpi, $dimensions: false) {
+// Same as `background-hdpi` but inline.
+@mixin inline-background-hdpi($image, $attr: '', $dimensions: $background-hdpi-dimensions) {
+  $image-hdpi: $image + "-x2.png";
+  $image: $image + ".png";
   background-image: inline-image($image);
+  @if $attr != '' {
+    background: $attr;
+  }
   @if $dimensions {
     @include image-dimensions($image);
   }
   @include media-hdpi {
     background-image: inline-image($image-hdpi);
-    @include image-background-size($image);
+    @include background-size(image-width($image) image-height($image));
   }
 }

--- a/stylesheets/_compass-hdpi.scss
+++ b/stylesheets/_compass-hdpi.scss
@@ -160,14 +160,12 @@ $generated-image-folder: false !default;
 
 // Set a normal and HDPI background and optionally, attributes and dimensions.
 //
-// @param {String} $image normal image path
-// @param {String} $image-hdpi HDPI image path.
-// @param {Object} $attr additional background property values.
-// @param {Boolean} $dimensions specify image dimensions.
-@mixin background-hdpi($image, $image-hdpi, $attr: '', $dimensions: $background-hdpi-dimensions) {
+// If `$attributes` is `true`, background attributes will be specified.
+// If `$dimensions` is `true`, the sprite dimensions will specified.
+@mixin background-hdpi($image, $image-hdpi, $attributes: '', $dimensions: $background-hdpi-dimensions) {
   background-image: image-url($image);
-  @if $attr != '' {
-    background: $attr;
+  @if $attributes != '' {
+    background: $attributes;
   }
   @if $dimensions {
     @include image-dimensions($image);
@@ -179,10 +177,10 @@ $generated-image-folder: false !default;
 }
 
 // Same as `background-hdpi` but inline.
-@mixin inline-background-hdpi($image, $image-hdpi, $attr: '', $dimensions: $background-hdpi-dimensions) {
+@mixin inline-background-hdpi($image, $image-hdpi, $attributes: '', $dimensions: $background-hdpi-dimensions) {
   background-image: inline-image($image);
   @if $attr != '' {
-    background: $attr;
+    background: $attributes
   }
   @if $dimensions {
     @include image-dimensions($image);

--- a/stylesheets/_compass-hdpi.scss
+++ b/stylesheets/_compass-hdpi.scss
@@ -160,23 +160,11 @@ $generated-image-folder: false !default;
 
 // Set a normal and HDPI background and optionally, attributes and dimensions.
 //
-// You must have a {filename}-x2 file in the same directory and twice the size
-// as your {filename} file.
-//
-// Example:
-//   li {
-//     @include background-hdpi(logo);
-//   }
-//   .facebook-icon {
-//     @include background-hdpi(social/facebook, #fff no-repeat right);
-//   }
-//
-// @param {String} $image normal image path without file extension.
+// @param {String} $image normal image path
+// @param {String} $image-hdpi HDPI image path.
 // @param {Object} $attr additional background property values.
 // @param {Boolean} $dimensions specify image dimensions.
-@mixin background-hdpi($image, $attr: '', $dimensions: $background-hdpi-dimensions) {
-  $image-hdpi: $image + "-x2.png";
-  $image: $image + ".png";
+@mixin background-hdpi($image, $image-hdpi, $attr: '', $dimensions: $background-hdpi-dimensions) {
   background-image: image-url($image);
   @if $attr != '' {
     background: $attr;
@@ -191,9 +179,7 @@ $generated-image-folder: false !default;
 }
 
 // Same as `background-hdpi` but inline.
-@mixin inline-background-hdpi($image, $attr: '', $dimensions: $background-hdpi-dimensions) {
-  $image-hdpi: $image + "-x2.png";
-  $image: $image + ".png";
+@mixin inline-background-hdpi($image, $image-hdpi, $attr: '', $dimensions: $background-hdpi-dimensions) {
   background-image: inline-image($image);
   @if $attr != '' {
     background: $attr;

--- a/stylesheets/_compass-hdpi.scss
+++ b/stylesheets/_compass-hdpi.scss
@@ -7,7 +7,14 @@ $disable-hdpi: false !default;
 // Force HDPI
 $force-hdpi: false !default;
 
-// Generate dimension styles when using background-hdpi().
+// Generate dimension styles when using sprite-hdpi().
+$sprite-hdpi-dimensions: true !default;
+
+// Set background image when using sprite-hdpi().
+$sprite-hdpi-set-background: false !default;
+
+// Generate dimension styles when using background-hdpi() and
+// inline-background-hdpi().
 $background-hdpi-dimensions: false !default;
 
 // This must be set to generated images folder relative to images set in
@@ -74,7 +81,7 @@ $generated-image-folder: false !default;
 // class or you can specify the `sprite-url` explicitly like this:
 //
 //     background: $map no-repeat;
-@mixin sprite-hdpi($map, $map-hdpi, $sprite, $dimensions: false, $offset-x: 0, $offset-y: 0, $set-background: false) {
+@mixin sprite-hdpi($map, $map-hdpi, $sprite, $dimensions: $sprite-hdpi-dimensions, $offset-x: 0, $offset-y: 0, $set-background: $sprite-hdpi-set-background) {
   @if $set-background {
     background-image: sprite-url($map);
     background-repeat: no-repeat;
@@ -108,7 +115,7 @@ $generated-image-folder: false !default;
 // If a base class is provided, then each class will extend it.
 //
 // If `$dimensions` is `true`, the sprite dimensions will specified.
-@mixin sprites-hdpi($map, $map-hdpi, $sprites: sprite-names($map), $base-class: false, $dimensions: false, $prefix: sprite-map-name($map), $offset-x: 0, $offset-y: 0, $set-background: false) {
+@mixin sprites-hdpi($map, $map-hdpi, $sprites: sprite-names($map), $base-class: false, $dimensions: $sprite-hdpi-dimensions, $prefix: sprite-map-name($map), $offset-x: 0, $offset-y: 0, $set-background: $sprite-hdpi-set-background) {
   @if $set-background {
     .#{$prefix} {
       background-image: sprite-url($map);

--- a/stylesheets/_compass-hdpi.scss
+++ b/stylesheets/_compass-hdpi.scss
@@ -7,11 +7,18 @@ $disable-hdpi: false !default;
 // Force HDPI
 $force-hdpi: false !default;
 
+// Declare the default map to use for when using sprite-hdpi().
+$sprite-hdpi-default-map: false !default;
+
+// Declare the default HDPI map to use for when using sprite-hdpi().
+$sprite-hdpi-default-map-hdpi: false !default;
+
 // Generate dimension styles when using sprite-hdpi().
 $sprite-hdpi-dimensions: true !default;
 
 // Set background image when using sprite-hdpi().
 $sprite-hdpi-set-background: false !default;
+
 
 // Generate dimension styles when using background-hdpi() and
 // inline-background-hdpi().
@@ -81,7 +88,7 @@ $generated-image-folder: false !default;
 // class or you can specify the `sprite-url` explicitly like this:
 //
 //     background: $map no-repeat;
-@mixin sprite-hdpi($map, $map-hdpi, $sprite, $dimensions: $sprite-hdpi-dimensions, $offset-x: 0, $offset-y: 0, $set-background: $sprite-hdpi-set-background) {
+@mixin sprite-hdpi($sprite, $map: $sprite-hdpi-default-map, $map-hdpi: $sprite-hdpi-default-map-hdpi, $dimensions: $sprite-hdpi-dimensions, $offset-x: 0, $offset-y: 0, $set-background: $sprite-hdpi-set-background) {
   @if $set-background {
     background-image: sprite-url($map);
     background-repeat: no-repeat;
@@ -115,7 +122,7 @@ $generated-image-folder: false !default;
 // If a base class is provided, then each class will extend it.
 //
 // If `$dimensions` is `true`, the sprite dimensions will specified.
-@mixin sprites-hdpi($map, $map-hdpi, $sprites: sprite-names($map), $base-class: false, $dimensions: $sprite-hdpi-dimensions, $prefix: sprite-map-name($map), $offset-x: 0, $offset-y: 0, $set-background: $sprite-hdpi-set-background) {
+@mixin sprites-hdpi($map: $default-map, $map-hdpi: $default-map-hdpi, $sprites: sprite-names($map), $base-class: false, $dimensions: $sprite-hdpi-dimensions, $prefix: sprite-map-name($map), $offset-x: 0, $offset-y: 0, $set-background: $sprite-hdpi-set-background) {
   @if $set-background {
     .#{$prefix} {
       background-image: sprite-url($map);


### PR DESCRIPTION
OK, I have made some alterations to this extension, have a look and see if you agree with them:
## Alter background-image-hdpi() and inline-background-image-hdpi()

Now called `background-hdpi()` and `inline-background-hdpi()` receptively.

These mixins now serve as an HDPI option to the entire family of background properties instead of just the image. My reasoning for this is that I think it's more common to use the css `background` property than it is to use `background-image`.

A user can now set all of these properties in one statement, for example:

```
@include background-hdpi(icons/logo.png, icons/logo@2x.png, no-repeat top left);
OR
@include inline-background-hdpi(icons/logo.png, icons/logo@2x.png, no-repeat top left);
```
## Added 3 new variables:
### $sprite-hdpi-dimensions: true !default;

You can disable the dimension styles by default when using `sprite-hdpi()` by setting the `$background-hdpi-dimensions` variable to `false` (default to `true`)
### $sprite-hdpi-set-background: false !default;

You can set the background image by default when using `sprite-hdpi()` by setting the `$sprite-hdpi-set-background` variable to `true` (default to `false`)
### $sprite-hdpi-dimensions: true !default;

You can set the dimension styles by default when using `background-hdpi()` and `inline-background-hdpi()` by setting the `$background-hdpi-dimensions` variable to `true` (default to `false`)

As a part of this change I have also set the `$sprite-hdpi-dimensions` to `true` by default. My reasoning for this is I think that if you are using a sprite, chances are you need the dimensions set as well or you will see the other sprites in the sprite map.
